### PR TITLE
Add support for v44

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Quick Touchpad Toggle
 A GNOME Shell Extension to more easily toggle the "disable touchpad while typing" setting.
 
-GNOME Shell versions 40, 41, 42 and 43 are supported.
+GNOME Shell versions 40, 41, 42, 43, and 44 are supported.
 
 ## Installation
 The extension can be installed [directly from the GNOME Extensions website](https://extensions.gnome.org/extension/5292/quick-touchpad-toggle/).

--- a/extension.js
+++ b/extension.js
@@ -17,6 +17,7 @@
  */
 
 const {Gio, GObject} = imports.gi;
+const {PACKAGE_VERSION} = imports.misc.config;
 
 const QuickSettings = imports.ui.quickSettings;
 const QuickSettingsMenu = imports.ui.main.panel.statusArea.quickSettings;
@@ -25,7 +26,7 @@ const FeatureToggle = GObject.registerClass(
 class FeatureToggle extends QuickSettings.QuickToggle {
     _init() {
         super._init({
-            label: 'Touchpad',
+            [Number(PACKAGE_VERSION.split('.')[0]) >= 44 ? 'title' : 'label']: 'Touchpad',
             toggleMode: true,
         });
 

--- a/metadata.json
+++ b/metadata.json
@@ -3,9 +3,10 @@
   "description": "Toggle the \"disable touchpad while typing\" setting more easily.",
   "name": "Quick Touchpad Toggle",
   "shell-version": [
-    "43"
+    "43", 
+    "44"
   ],
   "url": "https://github.com/kra-mo/quick-touchpad-toggle/",
   "uuid": "quick-touchpad-toggle@kramo.hu",
-  "version": 6
+  "version": 7
 }


### PR DESCRIPTION
Hi, @kra-mo ! Thank you for making this extension! I use it on my laptop, it's great! :D

I have tested it with Gnome 44 and as per the[ v44 extension port guide](https://gjs.guide/extensions/upgrading/gnome-shell-44.html#quicktoggle-and-quickmenutoggle), I have added a change to support that version as well. 

Thank you! 